### PR TITLE
Removing padding from main Container

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -104,7 +104,7 @@ export default function App() {
     <ThemeProvider theme={theme}>
       <CssBaseline />
       {<TopBar setUser={handleSetUser} changeView={changeView} profileData={profileData}/>}
-      <Container id='main-app-container' maxWidth={'sm'}>
+      <Container id='main-app-container' maxWidth={'sm'} sx={{ padding: 0 }}>
         <Suspense fallback={<p>Loading...</p>}>{renderView()}</Suspense>
       </Container>
       {<NavBar changeView={changeView} />}


### PR DESCRIPTION
Some views need to be the full width, so it makes more sense to have padding: 0 on the main Container component and have each view handle it's own spacing